### PR TITLE
Add patty (aka pancake) flipping game

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -217,6 +217,7 @@
   <nav>
     <h2 class="nav-section" id="Games">Games</h2>
     <a href="tetris.html">▶ Tong's Tetris</a>
+    <a href="patty-flip.html">▶ Tong's Patty</a>
     <a href="wordle.html">📝 Wordle</a>
     <a href="astroids.html">☄️ Astroids 🚀</a>
     <a href="condestructor.html">🤖 ConDestructor 👽</a>

--- a/wwwroot/patty-flip.html
+++ b/wwwroot/patty-flip.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Patty Flip</title>
+<style>
+  html,body {height:100%;margin:0;background:#111;color:#eee;font-family:system-ui,Segoe UI,Roboto,"Helvetica Neue",Arial;}
+  #game {display:block;margin:0 auto;background:#a8a8a8;box-shadow:0 6px 30px rgba(0,0,0,0.7);touch-action:none;}
+  .ui {position:absolute;left:14px;top:12px;background:rgba(0,0,0,0.35);padding:10px 14px;border-radius:8px;backdrop-filter:blur(4px);}
+  button {background:#ffcc66;border:0;padding:8px 12px;border-radius:6px;cursor:pointer;font-weight:600;}
+  #overlay {position:absolute;left:0;top:0;right:0;bottom:0;display:flex;align-items:center;justify-content:center;pointer-events:none;}
+  #msg {pointer-events:auto;background:rgba(0,0,0,0.6);color:white;padding:18px;border-radius:12px;text-align:center;}
+  small {color:#ddd;display:block;margin-top:8px;font-size:12px;}
+</style>
+</head>
+<body>
+<canvas id="game" width="900" height="600"></canvas>
+
+<div class="ui">
+  <div>Flips: <span id="score">0</span></div>
+  <div style="margin-top:8px">Hold to flip upward. Each 180° rotation = 1 flip.</div>
+  <div style="margin-top:10px"><button id="restart">Restart</button></div>
+</div>
+
+<div id="overlay" style="display:none">
+  <div id="msg"><h2>Game Over</h2><div id="endText"></div><div style="margin-top:12px"><button id="restart2">Restart</button></div></div>
+</div>
+
+<script>
+const canvas=document.getElementById('game');
+const ctx=canvas.getContext('2d');
+let W=canvas.width,H=canvas.height;
+const scoreEl=document.getElementById('score');
+const overlay=document.getElementById('overlay');
+const endText=document.getElementById('endText');
+document.getElementById('restart').onclick=restart;
+document.getElementById('restart2').onclick=restart;
+
+let pan,patty,mouseDown=false,holdStart=0;
+let score=0,gameOver=false;
+
+// ------------------- PAN -------------------
+class Pan{
+  constructor(x,y,length,thickness,handleLength){
+    this.x=x;this.y=y;
+    this.length=length;this.thickness=thickness;this.handleLength=handleLength;
+    this.angle=0;this.angularVel=0;
+    this.maxAngle=-Math.PI/4; // negative = right side up
+  }
+  update(dt){
+    if(mouseDown&&!gameOver){
+      const t=(performance.now()-holdStart);
+      const accel=-6.0*Math.min(1+2*t,8); // negative to go upward
+      this.angularVel+=accel*dt;
+    }else{
+      const spring=36;
+      this.angularVel+=(-this.angle*spring-this.angularVel*6)*dt;
+    }
+    this.angularVel=Math.max(Math.min(this.angularVel,12),-12);
+    this.angle+=this.angularVel*dt;
+    if(this.angle<this.maxAngle){this.angle=this.maxAngle;this.angularVel=0;}
+    if(this.angle>0){this.angle=0;this.angularVel=0;}
+  }
+  endpoints(){
+    // pivot at handle mid-left, pan extends right
+    const hx=Math.cos(this.angle),hy=Math.sin(this.angle);
+    const startX=this.x,startY=this.y;
+    const endX=startX+hx*this.length,endY=startY+hy*this.length;
+    return[{x:startX,y:startY},{x:endX,y:endY}];
+  }
+  velocityAtPoint(px,py){
+    const cx=this.x,cy=this.y;
+    const r={x:px-cx,y:py-cy};
+    return {x:-this.angularVel*r.y,y:this.angularVel*r.x};
+  }
+  draw(ctx){
+    ctx.save();
+    ctx.translate(this.x,this.y);
+    ctx.rotate(this.angle);
+    // handle on left
+    ctx.fillStyle='#332';
+    ctx.fillRect(-this.handleLength,-this.thickness*0.2,this.handleLength,this.thickness*0.4);
+    // pan body extends right
+    ctx.fillStyle='#444';
+    ctx.fillRect(0,-this.thickness/2,this.length,this.thickness);
+    ctx.restore();
+    // pivot dot
+    //ctx.fillStyle='#999';
+    //ctx.beginPath();ctx.arc(this.x,this.y,4,0,Math.PI*2);ctx.fill();
+  }
+}
+
+// ------------------- RECTANGULAR SOFTBODY -------------------
+class Patty{
+  constructor(cx,cy,w,h,cols,rows,stiffness=10){
+    this.cx=cx;this.cy=cy;this.w=w;this.h=h;
+    this.cols=cols;this.rows=rows;
+    this.stiffness=stiffness;
+    this.particles=[];this.constraints=[];
+    this.makeGrid();
+    this.accumAngle=0;this.lastAngle=this.markerAngle();
+  }
+  makeGrid(){
+    const dx=this.w/(this.cols-1),dy=this.h/(this.rows-1);
+    for(let j=0;j<this.rows;j++){
+      for(let i=0;i<this.cols;i++){
+        const x=this.cx+(i-this.cols/2)*dx;
+        const y=this.cy+(j-this.rows/2)*dy;
+        this.particles.push({x,px:x,y,py:y,vx:0,vy:0});
+      }
+    }
+    const idx=(i,j)=>j*this.cols+i;
+    const kMain=this.stiffness;
+    for(let j=0;j<this.rows;j++){
+      for(let i=0;i<this.cols;i++){
+        const a=idx(i,j);
+        if(i<this.cols-1)this.constraints.push({a,b:idx(i+1,j),rest:dx,k:kMain});
+        if(j<this.rows-1)this.constraints.push({a,b:idx(i,j+1),rest:dy,k:kMain});
+        // diagonals for stiffness
+        if(i<this.cols-1&&j<this.rows-1)this.constraints.push({a,b:idx(i+1,j+1),rest:Math.hypot(dx,dy),k:kMain});
+        if(i>0&&j<this.rows-1)this.constraints.push({a,b:idx(i-1,j+1),rest:Math.hypot(dx,dy),k:kMain});
+      }
+    }
+  }
+  markerAngle(){
+    const c=this.center();const p=this.particles[0];
+    return Math.atan2(p.y-c.y,p.x-c.x);
+  }
+  center(){
+    let sx=0,sy=0;for(const p of this.particles){sx+=p.x;sy+=p.y;}
+    return {x:sx/this.particles.length,y:sy/this.particles.length};
+  }
+  applyForces(dt){
+    const g=1000;
+    for(const p of this.particles){
+        p.vy+=g*dt;
+        p.vx*=0.995;
+        p.vy*=0.995;
+    }
+  }
+  integrate(dt){for(const p of this.particles){p.x+=p.vx*dt;p.y+=p.vy*dt;}}
+  satisfy(){
+    for(let it=0;it<4;it++){
+      for(const c of this.constraints){
+        const A=this.particles[c.a],B=this.particles[c.b];
+        let dx=B.x-A.x,dy=B.y-A.y;
+        let len=Math.hypot(dx,dy)||1;
+        const err=(len-c.rest);
+        const corr=(c.k/(c.k+100))*(err/len)*0.5;
+        const mx=dx*corr,my=dy*corr;
+        A.x+=mx;A.y+=my;
+        B.x-=mx;B.y-=my;
+      }
+    }
+  }
+  step(dt){
+    this.applyForces(dt);
+    this.integrate(dt);
+    this.satisfy();
+    for(const p of this.particles){
+      p.vx=(p.x-p.px)/dt;p.vy=(p.y-p.py)/dt;p.px=p.x;p.py=p.y;
+    }
+    const newA=this.markerAngle();
+    let da=newA-this.lastAngle;
+    while(da>Math.PI)da-=2*Math.PI;
+    while(da<-Math.PI)da+=2*Math.PI;
+    this.accumAngle+=da;this.lastAngle=newA;
+  }
+  draw(ctx){
+    const cm=this.center();
+    // outline
+    const top=this.particles.slice(0,this.cols);
+    const bottom=this.particles.slice(-this.cols).reverse();
+    ctx.beginPath();
+    ctx.moveTo(top[0].x,top[0].y);
+    for(let p of top)ctx.lineTo(p.x,p.y);
+    for(let p of bottom)ctx.lineTo(p.x,p.y);
+    ctx.closePath();
+    //const g=ctx.createLinearGradient(cm.x,cm.y-this.h/2,cm.x,cm.y+this.h/2);
+    //g.addColorStop(0,'#d96a3b');g.addColorStop(1,'#772a1f'); // for color gradient
+    ctx.fillStyle='#d96a3b';
+    ctx.fill();
+    ctx.lineWidth=1.5;ctx.strokeStyle='rgba(0,0,0,0.3)';ctx.stroke();
+    // marker
+    //const p0=this.particles[0];
+    //ctx.beginPath();ctx.arc(p0.x,p0.y,4,0,Math.PI*2);ctx.fillStyle='#ffd95a';ctx.fill();
+  }
+}
+
+// ------------------- COLLISIONS -------------------
+function handlePanCollisions(patty,pan){
+  const [A,B]=pan.endpoints();
+  const sx=B.x-A.x,sy=B.y-A.y,segLen2=sx*sx+sy*sy;
+  const thickness=7,restitution=0.7,friction=0.1;
+  for(const p of patty.particles){
+    const vx=p.x-A.x,vy=p.y-A.y;
+    const t=Math.max(0,Math.min(1,(vx*sx+vy*sy)/(segLen2||1)));
+    const cx=A.x+sx*t,cy=A.y+sy*t;
+    let nx=p.x-cx,ny=p.y-cy;
+    let dist=Math.hypot(nx,ny);
+    if(dist<thickness){
+      if(dist===0){nx=0;ny=-1;dist=1;}else{nx/=dist;ny/=dist;}
+      const pv=pan.velocityAtPoint(cx,cy);
+      const rvx=p.vx-pv.x,rvy=p.vy-pv.y;
+      const reln=rvx*nx+rvy*ny;
+      const penetration=0.5*(thickness-dist);
+      p.x+=nx*penetration;p.y+=ny*penetration;
+      if(reln<0){
+        p.vx-=(1+restitution)*reln*nx;
+        p.vy-=(1+restitution)*reln*ny;
+      }
+      const tx=-ny,ty=nx;
+      const relt=p.vx*tx+p.vy*ty-(pv.x*tx+pv.y*ty);
+      const fr=relt*(1-friction);
+      p.vx-=fr*tx;p.vy-=fr*ty;
+    }
+  }
+}
+
+// ------------------- GAME -------------------
+function resetStatsUI(){
+    score=0;scoreEl.textContent=0;gameOver=false;overlay.style.display='none';
+}
+function makePan(){
+    pan=new Pan(W/2-220,H*0.56,300,14,110);
+}
+function makePatty(){
+    patty=new Patty(W/2,H*0.35,140,20,8,3,10);
+    for(const p of patty.particles)p.vy=100;
+}
+function init(){
+    makePan();
+    makePatty();
+    resetStatsUI();
+}
+function restart(){
+    makePatty();
+    resetStatsUI();
+}
+
+canvas.addEventListener('mousedown',e=>{e.preventDefault();if(!gameOver){mouseDown=true;holdStart=performance.now();}});
+window.addEventListener('mouseup',()=>mouseDown=false);
+canvas.addEventListener('touchstart',e=>{e.preventDefault();mouseDown=true;holdStart=performance.now();},{passive:false});
+window.addEventListener('touchend',()=>mouseDown=false);
+
+function step(){
+  const now=performance.now();
+  const dt=0.018 // update interval
+  if(!gameOver){
+    pan.update(dt);
+    for(let i=0;i<3;i++){
+        patty.step(dt/3);
+        for(let j=0;j<4;j++){ // extra collision iterations
+            handlePanCollisions(patty,pan);
+            patty.satisfy();
+        }
+    }
+    const absA=Math.abs(patty.accumAngle);
+    if(absA>=Math.PI){const n=Math.floor(absA/(Math.PI));score+=n;patty.accumAngle-=Math.sign(patty.accumAngle)*n*Math.PI;scoreEl.textContent=score;}
+    const cm=patty.center();
+    if(cm.y>H+40){gameOver=true;overlay.style.display='flex';endText.innerHTML=`You scored <b>${score}</b> flips.<small>Click restart to try again.</small>`;}
+  }
+  render();requestAnimationFrame(step);
+}
+
+function render(){
+  ctx.clearRect(0,0,W,H);
+  //const g=ctx.createLinearGradient(0,H*0.5,0,H);
+  //g.addColorStop(0,'#222');g.addColorStop(1,'#0e0e0e'); // for gradient color
+  ctx.fillStyle='#a8a8a8'; // set solid color
+  ctx.fillRect(0,0,W,H);
+  pan.draw(ctx);
+  patty.draw(ctx);
+  ctx.fillStyle='rgba(255,255,255,0.06)';ctx.fillRect(0,H-24,W,24);
+  ctx.fillStyle='#ddd';ctx.font='13px system-ui,Arial';
+}
+
+init();requestAnimationFrame(step);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Prompt used for Grant:
```
Make a burger flipping game where the player's objective is to flip the burger patty (thin rectangle in shape because viewed from side) as many times as possible. If the patty falls off the pan, the game is over, and the player has to restart. 

Use softbody physics for the patty, but the pan that is used to flip the burger patty is simply a rigid, thin rectangle, which has an extended thinner rigid rectangle for the pan handle. The patty spawns in the middle of the screen and drops down on to the pan, which is slightly lower from the center of the screen. The pan is horizontal, but can flip up at an angle of 45 degrees. Clicking (mouse left-click or touch click via mobile) and holding anywhere on the screen causes the pan to flip up to that 45 degrees, but at an accelerating speed the longer the click is held.
```

I did fix it heavily after first creation though, but that prompt gets you very close. Oh, and I used a custom GPT: https://chatgpt.com/g/g-Nd8T0aWmn-game-builder-ai

There are a few bugs and some tuning to be made. UI is a mess and needs fixing for sure. Otherwise...it's something resembling pancake. I went with burger flip for originality in naming.